### PR TITLE
Update logging to wrapper class

### DIFF
--- a/src/CdsWeb/CdsWeb.csproj
+++ b/src/CdsWeb/CdsWeb.csproj
@@ -6,8 +6,8 @@
 
   <ItemGroup>
     <PackageReference Include="BouncyCastle.NetCore" Version="1.8.5" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Powerplatform.Cds.Client" Version="0.0.1.9-Alpha" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Powerplatform.Cds.Client" Version="0.0.1.11-Alpha" />
   </ItemGroup>
 
 </Project>

--- a/src/CdsWeb/Extensions/CdsServiceClientExtensions.cs
+++ b/src/CdsWeb/Extensions/CdsServiceClientExtensions.cs
@@ -13,10 +13,9 @@ namespace CdsWeb.Extensions
     /// </summary>
     public class CdsServiceClientWrapper
     {
-
         public readonly CdsServiceClient CdsServiceClient;
 
-        public CdsServiceClientWrapper(string connectionString, ILogger<CdsServiceClientWrapper> logger, string traceLevel)
+        public CdsServiceClientWrapper(string connectionString, ILogger<CdsServiceClientWrapper> logger, string traceLevel = "Off")
         {
             TraceControlSettings.TraceLevel = 
                 (System.Diagnostics.SourceLevels)Enum.Parse(
@@ -28,7 +27,7 @@ namespace CdsWeb.Extensions
                     )
                 );
 
-            CdsServiceClient = new CdsServiceClient(connectionString);
+            CdsServiceClient = new CdsServiceClient(connectionString ?? throw new ArgumentNullException(nameof(connectionString)));
         }
     }
 

--- a/src/CdsWeb/Extensions/CdsServiceClientExtensions.cs
+++ b/src/CdsWeb/Extensions/CdsServiceClientExtensions.cs
@@ -17,7 +17,7 @@ namespace CdsWeb.Extensions
 
         public CdsServiceClientWrapper(string connectionString, ILogger<CdsServiceClientWrapper> logger, string traceLevel = "Off")
         {
-            TraceControlSettings.TraceLevel = 
+            TraceControlSettings.TraceLevel =
                 (System.Diagnostics.SourceLevels)Enum.Parse(
                     typeof(System.Diagnostics.SourceLevels), traceLevel);
 
@@ -72,8 +72,8 @@ namespace CdsWeb.Extensions
 
             services.AddSingleton(sp =>
                 new CdsServiceClientWrapper(
-                    cdsServiceClientOptions.ConnectionString, 
-                    sp.GetRequiredService<ILogger<CdsServiceClientWrapper>>(), 
+                    cdsServiceClientOptions.ConnectionString,
+                    sp.GetRequiredService<ILogger<CdsServiceClientWrapper>>(),
                     cdsServiceClientOptions.TraceLevel)
                 );
 


### PR DESCRIPTION
Move logging into wrapper class to provide proper implementation of ILogger without building service provider.  Update reference packages